### PR TITLE
refactor: migrate layer storage from nested dirs to flat content-addressable store

### DIFF
--- a/crates/repx-core/src/logging.rs
+++ b/crates/repx-core/src/logging.rs
@@ -308,6 +308,22 @@ pub fn init_session_logger(config: &LoggingConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
+pub fn init_stderr_logger() {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(get_default_log_level().to_string()));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .with_timer(LocalTimeFormatter)
+        .with_ansi(true)
+        .with_target(false)
+        .with_line_number(false)
+        .with_file(false)
+        .with_level(true)
+        .init();
+}
+
 pub fn init_tui_logger(config: &LoggingConfig) -> Result<(), ConfigError> {
     let xdg_dirs = xdg::BaseDirectories::with_prefix("repx");
     let cache_home = xdg_dirs.get_cache_home().ok_or_else(|| {

--- a/crates/repx-runner/src/cli.rs
+++ b/crates/repx-runner/src/cli.rs
@@ -137,6 +137,8 @@ pub struct InternalExecuteArgs {
     pub mount_paths: Vec<String>,
     #[arg(long)]
     pub executable_path: PathBuf,
+    #[arg(long, default_value_t = false, help = "Enable debug logging to stderr")]
+    pub debug: bool,
 }
 
 #[derive(Args)]

--- a/crates/repx-runner/src/commands/gc.rs
+++ b/crates/repx-runner/src/commands/gc.rs
@@ -134,6 +134,7 @@ pub async fn async_handle_internal_gc(args: InternalGcArgs) -> Result<(), CliErr
             "lab",
             "revision",
             "readme",
+            "store",
         ];
 
         for entry in fs::read_dir(&artifacts_dir)? {

--- a/crates/repx-runner/src/main.rs
+++ b/crates/repx-runner/src/main.rs
@@ -18,6 +18,8 @@ fn main() {
             | Commands::InternalGc(_)
     );
 
+    let debug_requested = matches!(&cli.command, Commands::InternalExecute(args) if args.debug);
+
     if !is_internal {
         let logging_config = config::load_config().map(|c| c.logging).unwrap_or_default();
 
@@ -27,6 +29,8 @@ fn main() {
                 format!("[ERROR] Failed to initialize session logger: {}", e).red()
             );
         }
+    } else if debug_requested {
+        logging::init_stderr_logger();
     }
 
     if let Err(e) = run(cli) {

--- a/nix/checks/runtime/incremental-sync-test.nix
+++ b/nix/checks/runtime/incremental-sync-test.nix
@@ -99,10 +99,10 @@ pkgs.testers.runNixOSTest {
     print("--- 3. First Sync & Run ---")
     client.succeed("repx run simulation-run --lab ${referenceLab}")
 
-    server.succeed("ls -R /home/repxuser/repx-store/images")
+    server.succeed("ls -R /home/repxuser/repx-store/artifacts/images")
 
     print("--- 4. Sabotage: Deleting a layer ---")
-    layers = server.succeed("find /home/repxuser/repx-store/images -name 'layer.tar'").splitlines()
+    layers = server.succeed("find /home/repxuser/repx-store/artifacts/images -name 'layer.tar'").splitlines()
     if not layers:
         raise Exception("No layers found on server!")
     victim_layer = layers[0]

--- a/nix/lib/lab-packagers.nix
+++ b/nix/lib/lab-packagers.nix
@@ -5,47 +5,72 @@
 let
   labVersion = "0.1.3";
 
-  mkHostTools =
-    let
-      rsyncStatic =
-        (pkgs.pkgsStatic.rsync.override {
-          enableXXHash = false;
-        }).overrideAttrs
-          (_: {
-            doCheck = false;
-          });
-    in
-    pkgs.runCommand "host-tools"
-      {
-        buildInputs = [
-          pkgs.pkgsStatic.coreutils
-          pkgs.pkgsStatic.jq
-          pkgs.pkgsStatic.findutils
-          pkgs.pkgsStatic.gnused
-          pkgs.pkgsStatic.gnugrep
-          pkgs.pkgsStatic.bash
-          pkgs.pkgsStatic.gnutar
-          pkgs.pkgsStatic.pigz
-          pkgs.pkgsStatic.bubblewrap
-          rsyncStatic
-          pkgs.pkgsStatic.openssh
-        ];
-      }
-      ''
-        mkdir -p $out/bin
-        cp ${pkgs.pkgsStatic.coreutils}/bin/* $out/bin/
-        cp ${pkgs.pkgsStatic.jq}/bin/jq $out/bin/
-        cp ${pkgs.pkgsStatic.findutils}/bin/find $out/bin/
-        cp ${pkgs.pkgsStatic.findutils}/bin/xargs $out/bin/
-        cp ${pkgs.pkgsStatic.gnused}/bin/sed $out/bin/
-        cp ${pkgs.pkgsStatic.gnugrep}/bin/grep $out/bin/
-        cp ${pkgs.pkgsStatic.bash}/bin/bash $out/bin/
-        cp ${pkgs.pkgsStatic.gnutar}/bin/tar $out/bin/
-        cp ${pkgs.pkgsStatic.pigz}/bin/pigz $out/bin/gzip
-        cp ${pkgs.pkgsStatic.bubblewrap}/bin/bwrap $out/bin/
-        cp ${pkgs.pkgsStatic.openssh}/bin/* $out/bin/
-        cp ${rsyncStatic}/bin/rsync $out/bin/
-      '';
+  rsyncStatic =
+    (pkgs.pkgsStatic.rsync.override {
+      enableXXHash = false;
+    }).overrideAttrs
+      (_: {
+        doCheck = false;
+      });
+
+  hostToolBinaries = [
+    {
+      pkg = pkgs.pkgsStatic.coreutils;
+      bins = null;
+    }
+    {
+      pkg = pkgs.pkgsStatic.jq;
+      bins = [ "jq" ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.findutils;
+      bins = [
+        "find"
+        "xargs"
+      ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.gnused;
+      bins = [ "sed" ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.gnugrep;
+      bins = [ "grep" ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.bash;
+      bins = [ "bash" ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.gnutar;
+      bins = [ "tar" ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.pigz;
+      bins = [
+        {
+          src = "pigz";
+          dst = "gzip";
+        }
+      ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.bubblewrap;
+      bins = [ "bwrap" ];
+    }
+    {
+      pkg = pkgs.pkgsStatic.openssh;
+      bins = null;
+    }
+    {
+      pkg = rsyncStatic;
+      bins = [ "rsync" ];
+    }
+  ];
+
+  hostToolsHash = builtins.hashString "sha256" (
+    pkgs.lib.concatMapStringsSep "-" (spec: builtins.baseNameOf (toString spec.pkg)) hostToolBinaries
+  );
 
   buildLabCoreAndManifest =
     {
@@ -123,35 +148,60 @@ let
       };
       rootMetadataFilename = builtins.baseNameOf (toString rootMetadata);
 
-      jobs =
-        let
-          jobPaths = builtins.concatStringsSep " " (map toString allJobDerivations);
-        in
-        pkgs.runCommand "lab-jobs-all"
-          {
-            JOB_PATHS = jobPaths;
-          }
-          ''
-            mkdir -p $out
-            for job_path in $JOB_PATHS; do
-              cp -rL -T "$job_path" "$out/$(basename "$job_path")"
-            done
-          '';
-
       labCore = pkgs.stdenv.mkDerivation {
         name = "hpc-lab-core";
         version = labVersion;
 
         nativeBuildInputs = [
-          jobs
-          mkHostTools
+          pkgs.jq
         ];
 
         buildCommand = ''
-          mkdir -p $out/jobs $out/revision $out/host-tools
+          mkdir -p $out/store $out/revision $out/jobs $out/host-tools/${hostToolsHash}/bin
 
-          cp -R ${jobs}/* $out/jobs
-          cp -r ${mkHostTools} $out/host-tools/$(basename ${mkHostTools})
+          ${pkgs.lib.concatMapStringsSep "\n" (
+            toolSpec:
+            let
+              inherit (toolSpec) pkg;
+              pkgHash = builtins.baseNameOf (toString pkg);
+            in
+            if toolSpec.bins == null then
+              ''
+                for bin in ${pkg}/bin/*; do
+                  binname=$(basename "$bin")
+                  storename="${pkgHash}-$binname"
+                  if [ ! -f "$out/store/$storename" ]; then
+                    cp "$bin" "$out/store/$storename"
+                  fi
+                  ln -sf "../../../store/$storename" "$out/host-tools/${hostToolsHash}/bin/$binname"
+                done
+              ''
+            else
+              pkgs.lib.concatMapStringsSep "\n" (
+                binSpec:
+                let
+                  srcName = if builtins.isAttrs binSpec then binSpec.src else binSpec;
+                  dstName = if builtins.isAttrs binSpec then binSpec.dst else binSpec;
+                  storeName = "${pkgHash}-${srcName}";
+                in
+                ''
+                  if [ ! -f "$out/store/${storeName}" ]; then
+                    cp ${pkg}/bin/${srcName} "$out/store/${storeName}"
+                  fi
+                  ln -sf "../../../store/${storeName}" "$out/host-tools/${hostToolsHash}/bin/${dstName}"
+                ''
+              ) toolSpec.bins
+          ) hostToolBinaries}
+
+          ${pkgs.lib.concatMapStringsSep "\n" (
+            jobDrv:
+            let
+              jobBasename = builtins.baseNameOf (toString jobDrv);
+            in
+            ''
+              cp -rL ${jobDrv} $out/jobs/${jobBasename}
+            ''
+          ) allJobDerivations}
 
           cp ${rootMetadata} "$out/revision/${rootMetadataFilename}"
 
@@ -160,17 +210,50 @@ let
           '') (pkgs.lib.attrValues metadataDrvs)}
 
           ${pkgs.lib.optionalString includeImages ''
-            mkdir -p $out/image
-            ${pkgs.lib.concatMapStringsSep "\n" (imageDrv: ''
-              image_tarball=$(${pkgs.findutils}/bin/find "${imageDrv}" -name "*.tar.gz" -o -name "*.tar" | head -n 1)
-              if [ -z "$image_tarball" ]; then
-                echo "Error: Could not find container image tarball in ${imageDrv}"; exit 1;
-              fi
-              final_filename=$(basename "${imageDrv}")
-              image_dir="$out/image/$final_filename"
-              mkdir -p "$image_dir"
-              ${pkgs.gnutar}/bin/tar -xf "$image_tarball" -C "$image_dir"
-            '') imageDerivations}
+            mkdir -p $out/images
+
+            ${pkgs.lib.concatMapStringsSep "\n" (
+              imageDrv:
+              let
+                imageBasename = builtins.baseNameOf (toString imageDrv);
+              in
+              ''
+                image_tarball=$(${pkgs.findutils}/bin/find "${imageDrv}" -name "*.tar.gz" -o -name "*.tar" | head -n 1)
+                if [ -z "$image_tarball" ]; then
+                  echo "Error: Could not find container image tarball in ${imageDrv}"; exit 1;
+                fi
+
+                image_dir="$out/images/${imageBasename}"
+                mkdir -p "$image_dir"
+
+                temp_extract=$(mktemp -d)
+                ${pkgs.gnutar}/bin/tar -xf "$image_tarball" -C "$temp_extract"
+
+                cp "$temp_extract/manifest.json" "$image_dir/manifest.json"
+
+                for json_file in "$temp_extract"/*.json; do
+                  if [ -f "$json_file" ] && [ "$(basename "$json_file")" != "manifest.json" ]; then
+                    cp "$json_file" "$image_dir/"
+                  fi
+                done
+
+                layer_paths=$(${pkgs.jq}/bin/jq -r '.[0].Layers[]' "$image_dir/manifest.json")
+
+                for layer_path in $layer_paths; do
+                  layer_hash=$(dirname "$layer_path")
+                  layer_store_name="''${layer_hash}-layer.tar"
+
+                  if [ ! -f "$out/store/$layer_store_name" ]; then
+                    cp "$temp_extract/$layer_path" "$out/store/$layer_store_name"
+                  fi
+
+                  mkdir -p "$image_dir/$layer_hash"
+                  ln -s "../../../store/$layer_store_name" "$image_dir/$layer_hash/layer.tar"
+                done
+
+                rm -rf "$temp_extract"
+              ''
+            ) imageDerivations}
           ''}
         '';
       };
@@ -223,12 +306,9 @@ let
 
         buildCommand = ''
           mkdir -p $out $out/lab $out/readme
-          cp -rL ${artifacts.labCore}/* $out/
-
+          cp -r --no-dereference ${artifacts.labCore}/* $out/
           cp ${artifacts.labManifest} $out/lab/$(basename ${artifacts.labManifest})
-
           cp ${readme} $out/readme/$(basename ${readme})
-
           echo "Lab directory created successfully."
         '';
       };

--- a/nix/lib/metadata.nix
+++ b/nix/lib/metadata.nix
@@ -41,7 +41,7 @@ let
       imageDrv = runDef.image;
       imagePath =
         if includeImages && imageDrv != null then
-          "image/" + (builtins.baseNameOf (toString imageDrv))
+          "images/" + (builtins.baseNameOf (toString imageDrv))
         else
           null;
 


### PR DESCRIPTION
## Summary
- Replace `layers/{hash}/layer.tar` directory structure with flat `store/{hash}-layer.tar` format
- Enable deduplication across images sharing common layers
- Simplify rsync operations and unify storage format between local/SSH targets
## Additional Changes
- Add `--chmod=Du+w` to rsync for proper directory permissions
- Fix symlink detection in local target
- Add `--debug` flag for internal executor stderr logging
- Canonicalize job package paths in bwrap runtime